### PR TITLE
Missing @Inject annotation

### DIFF
--- a/quarkus-fagligfredag-demo/src/main/java/dk/jarry/fagligfredag/ping/boundary/PingResource.java
+++ b/quarkus-fagligfredag-demo/src/main/java/dk/jarry/fagligfredag/ping/boundary/PingResource.java
@@ -1,5 +1,6 @@
 package dk.jarry.fagligfredag.ping.boundary;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
@@ -7,7 +8,8 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 @Path("pings")
 public class PingResource {
-	
+
+	@Inject
 	@ConfigProperty(name = "pingMessage", defaultValue = "pingMessage need config..")
 	String message;
 	


### PR DESCRIPTION
When using the `@ConfigProperty` annotation from Microprofile on a field, the field must be annotated with `@Inject`.